### PR TITLE
Update media keys to use querySelectorAll and "aria-label" attribute.

### DIFF
--- a/SiriusXMPlayer/MainWindow.xaml.cs
+++ b/SiriusXMPlayer/MainWindow.xaml.cs
@@ -12,9 +12,9 @@ namespace SiriusXMPlayer;
 public partial class MainWindow : Window
 {
     //these button classes are specific to the HTML for siriusxm. if they change their code we'll have to adjust
-    private const string _siriusPreviousTrackButtonClassName = "skip-back-btn";
-    private const string _siriusNextTrackButtonClassName = "skip-forward-btn";
-    private const string _siriusPlayPauseButtonClassName = "play-pause-btn";
+    private const string _siriusPreviousTrackSelector = "button[aria-label='Skip Back']";
+    private const string _siriusNextTrackButtonSelector= "button[aria-label='Skip Forward']";
+    private const string _siriusPlayPauseButtonSelector = "button[aria-label='Play'], button[aria-label='Pause']";
 
     private readonly MainWindowViewModel _viewModel;
     private readonly IMediaKeyEventService _mediaKeyEventService;
@@ -91,27 +91,27 @@ public partial class MainWindow : Window
     private void _mediaKeyEventService_NextTrackPressed(object? sender, EventArgs e)
     {
         _logger.LogInformation("Next Track");
-        this.PressButton(_siriusNextTrackButtonClassName);
+        this.PressButton(_siriusNextTrackButtonSelector);
     }
 
     private void _mediaKeyEventService_PreviousTrackPressed(object? sender, EventArgs e)
     {
         _logger.LogInformation("Previous Track");
-        this.PressButton(_siriusPreviousTrackButtonClassName);
+        this.PressButton(_siriusPreviousTrackSelector);
     }
 
     private void _mediaKeyEventService_PlayPausePressed(object? sender, EventArgs e)
     {
         _logger.LogInformation("PlayPause");
-        this.PressButton(_siriusPlayPauseButtonClassName);
+        this.PressButton(_siriusPlayPauseButtonSelector);
     }
 
-    private void PressButton(string className)
+    private void PressButton(string selectorName)
     {
         //sirius is not using jquery so we are using vanilla JS, which is fine
         //   we are invoking click on the first matching element... of course what if there are more than one or none... 
         //   that would mean they changed their code and we'll have to adjust this
-        var t = browser.ExecuteScriptAsync($"document.getElementsByClassName('{className}')[0].click();");
+        var t = browser.ExecuteScriptAsync($"document.querySelectorAll(\"{selectorName}\")[0].click();");
     }
 
     private void Exit_MenuItem_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
The current SiriusXM web player no longer uses class names like "play-pause-btn" for its buttons.  Switch to using querySelectorAll to identify elements using the "aria-label" attribute.

This pull request should resolve issue #5.